### PR TITLE
perf: use lookahead iterator for keyword completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,7 +1353,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owl-ms-language-server"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cached",
  "cc",
@@ -2688,7 +2688,7 @@ checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
 
 [[package]]
 name = "tree-sitter-owl-ms"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cc",
  "tree-sitter-c2rust",

--- a/crates/owl-ms-language-server/src/lib.rs
+++ b/crates/owl-ms-language-server/src/lib.rs
@@ -32,13 +32,14 @@ use tower_lsp::jsonrpc::Result;
 #[allow(clippy::wildcard_imports)]
 use tower_lsp::lsp_types::{self, *};
 use tower_lsp::{Client, LanguageServer};
-use tree_sitter_c2rust::Language;
+use tree_sitter_c2rust::{Language, LookaheadIterator};
 use workspace::{node_text, trim_full_iri, Workspace};
 
 use crate::sync_backend::SyncBackend;
 use crate::web::HttpClient;
 use crate::workspace::{
-    Document, DocumentReference, FormattingSettings, FrameType, InternalDocument,
+    word_before_character, Document, DocumentReference, FormattingSettings, FrameType,
+    InternalDocument,
 };
 
 // Re-export for benchmarks
@@ -773,13 +774,15 @@ impl LanguageServer for Backend {
             self.encoding(),
         )?;
 
-        let kws = timeit("try_keywords_at_position", || {
-            doc.try_keywords_at_position(pos)
+        let kws = timeit("lookahead iterator keywords", || {
+            doc.get_keyword_competions_at(pos)
         });
 
         debug!("The resultingn kws are {kws:#?}");
 
-        let pos_one_left = pos.moved_left(1, doc.rope());
+        let iri_completions = doc.get_iri_completions_at(pos, workspace);
+
+        debug!("The resulting iris are {iri_completions:#?}");
 
         let keywords_completion_items = kws.into_iter().map(|keyword| CompletionItem {
             label: keyword,
@@ -787,48 +790,23 @@ impl LanguageServer for Backend {
             ..Default::default()
         });
 
-        let mut items = vec![];
-
-        let node = doc
-            .tree()
-            .root_node()
-            .named_descendant_for_point_range(pos_one_left.into(), pos_one_left.into())
-            .expect("The pos to be in at least one node");
-
-        // Generate the list of iris that can be inserted.
-        let partial_text = node_text(&node, doc.rope()).to_string();
-
-        if node.kind() == "simple_iri" {
-            debug!("Try iris...");
-
-            let iris: Vec<CompletionItem> = workspace
-                .search_frame(&partial_text)
+        let iri_completion_items =
+            iri_completions
                 .into_iter()
-                .unique_by(|(_, iri, _)| iri.clone())
-                .sorted_unstable_by_key(|(v, _, _)| v.clone())
-                .filter_map(|(full, maybe_full_iri, frame)| {
-                    let iri = doc.full_iri_to_shorter_iri(&maybe_full_iri);
-
-                    if iri == partial_text {
-                        None
-                    } else {
-                        Some(CompletionItem {
-                            label: frame.label().unwrap_or(full),
-                            kind: Some(CompletionItemKind::REFERENCE),
-                            detail: Some(frame.info_display(workspace)),
-                            insert_text: Some(iri),
-                            // TODO #29 add details from the frame
-                            ..Default::default()
-                        })
+                .map(|(label, details, insert_text)| {
+                    CompletionItem {
+                        label,
+                        kind: Some(CompletionItemKind::REFERENCE),
+                        detail: Some(details),
+                        insert_text: Some(insert_text),
+                        // TODO #29 add details from the frame
+                        ..Default::default()
                     }
-                })
-                // TODO #29 add items for simple iri, abbriviated iri and full iri
-                // Take the shortest one maybe
-                .collect();
-            items.extend(iris);
-        }
+                });
 
-        items.extend(keywords_completion_items);
+        let items: Vec<CompletionItem> = keywords_completion_items
+            .chain(iri_completion_items)
+            .collect();
 
         debug!("completion item count {}", items.len());
 

--- a/crates/owl-ms-language-server/src/lib.rs
+++ b/crates/owl-ms-language-server/src/lib.rs
@@ -804,8 +804,8 @@ impl LanguageServer for Backend {
                     }
                 });
 
-        let items: Vec<CompletionItem> = keywords_completion_items
-            .chain(iri_completion_items)
+        let items: Vec<CompletionItem> = iri_completion_items
+            .chain(keywords_completion_items)
             .collect();
 
         debug!("completion item count {}", items.len());

--- a/crates/owl-ms-language-server/src/lib.rs
+++ b/crates/owl-ms-language-server/src/lib.rs
@@ -32,14 +32,13 @@ use tower_lsp::jsonrpc::Result;
 #[allow(clippy::wildcard_imports)]
 use tower_lsp::lsp_types::{self, *};
 use tower_lsp::{Client, LanguageServer};
-use tree_sitter_c2rust::{Language, LookaheadIterator};
+use tree_sitter_c2rust::Language;
 use workspace::{node_text, trim_full_iri, Workspace};
 
 use crate::sync_backend::SyncBackend;
 use crate::web::HttpClient;
 use crate::workspace::{
-    word_before_character, Document, DocumentReference, FormattingSettings, FrameType,
-    InternalDocument,
+    Document, DocumentReference, FormattingSettings, FrameType, InternalDocument,
 };
 
 // Re-export for benchmarks

--- a/crates/owl-ms-language-server/src/pos.rs
+++ b/crates/owl-ms-language-server/src/pos.rs
@@ -119,7 +119,7 @@ impl Position {
         rope.try_byte_to_char(self.byte_index(rope))
             .map_err(std::convert::Into::into)
             .inspect_log()
-            .unwrap_or(rope.len_chars() - 1)
+            .unwrap_or(rope.len_chars())
     }
 
     pub fn moved_right(self, char_offset: u32, rope: &Rope) -> Self {

--- a/crates/owl-ms-language-server/src/queries.rs
+++ b/crates/owl-ms-language-server/src/queries.rs
@@ -37,21 +37,8 @@ pub static GRAMMAR: LazyLock<Grammar> = LazyLock::new(|| {
     serde_json::from_str(tree_sitter_owl_ms::GRAMMAR).expect("valid grammar json")
 });
 
-pub static KEYWORDS: LazyLock<Vec<String>> = LazyLock::new(|| {
-    GRAMMAR
-        .rules
-        .iter()
-        .filter_map(|item| match item {
-            (rule_name, Rule::String { value }) if rule_name.starts_with("keyword_") => {
-                Some(value.clone())
-            }
-            _ => None,
-        })
-        .collect()
-});
-
 /// Maps keyword rule names to keyword texts
-/// Example: "keyword_functional" => "Functional:"
+/// Example: "keyword functional" => "Functional:"
 pub static KEYWORDS_MAP: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
     GRAMMAR
         .rules
@@ -407,7 +394,7 @@ mod tests {
 
     #[test]
     fn keywords_clone_should_return_all_keywords() {
-        let kws = KEYWORDS.clone();
+        let kws = KEYWORDS_MAP.clone();
 
         assert!(!kws.is_empty());
     }

--- a/crates/owl-ms-language-server/src/queries.rs
+++ b/crates/owl-ms-language-server/src/queries.rs
@@ -50,6 +50,21 @@ pub static KEYWORDS: LazyLock<Vec<String>> = LazyLock::new(|| {
         .collect()
 });
 
+/// Maps keyword rule names to keyword texts
+/// Example: "keyword_functional" => "Functional:"
+pub static KEYWORDS_MAP: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
+    GRAMMAR
+        .rules
+        .iter()
+        .filter_map(|item| match item {
+            (rule_name, Rule::String { value }) if rule_name.starts_with("keyword_") => {
+                Some((rule_name.clone(), value.clone()))
+            }
+            _ => None,
+        })
+        .collect()
+});
+
 pub struct AllQueries {
     pub import_query: Query,
     pub iri_query_all: Query,

--- a/crates/owl-ms-language-server/src/tests.rs
+++ b/crates/owl-ms-language-server/src/tests.rs
@@ -2118,6 +2118,69 @@ async fn backend_completion_should_not_panic() {
     // Assert
     // Does not panic!
 }
+
+#[test(tokio::test)]
+async fn backend_completion_on_empty_doc_should_suggest_ontology() {
+    setup();
+    // Arrange
+
+    let tmp_dir = arrange_workspace_folders(|_| vec![]);
+    let service = arrange_backend(
+        Some(WorkspaceFolder {
+            uri: Url::from_directory_path(tmp_dir.path()).unwrap(),
+            name: "test-doc".into(),
+        }),
+        vec![],
+    )
+    .await;
+
+    let url = Url::from_file_path(tmp_dir.path().join("test-doc.omn")).unwrap();
+
+    let ontology = ""; // EMPTY
+
+    service
+        .inner()
+        .did_open(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: url.clone(),
+                language_id: "owl2md".to_string(),
+                version: 0,
+                text: ontology.to_string(),
+            },
+        })
+        .await;
+
+    // Act
+
+    let completions = service
+        .inner()
+        .completion(CompletionParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri: url },
+                position: lsp_types::Position::new(0, 0),
+            },
+            work_done_progress_params: WorkDoneProgressParams {
+                work_done_token: None,
+            },
+            partial_result_params: PartialResultParams {
+                partial_result_token: None,
+            },
+            context: None,
+        })
+        .await;
+
+    // Assert
+
+    let completions = completions.unwrap().unwrap();
+    let items = match completions {
+        CompletionResponse::Array(completion_items) => completion_items,
+        CompletionResponse::List(_) => todo!(),
+    };
+    let labels = items.iter().map(|i| &i.label).collect_vec();
+    assert!(labels.contains(&&"Ontology:".to_string()));
+    assert!(labels.contains(&&"Prefix:".to_string()));
+}
+
 #[test(tokio::test)]
 async fn backend_completion_with_iri_should_complete_to_iri() {
     setup();

--- a/crates/owl-ms-language-server/src/workspace.rs
+++ b/crates/owl-ms-language-server/src/workspace.rs
@@ -48,9 +48,9 @@ use std::{
 };
 use tokio::task::JoinHandle;
 use tower_lsp::lsp_types::{
-    self, DiagnosticSeverity, DidChangeTextDocumentParams, InlayHint, InlayHintLabel,
-    PositionEncodingKind, SemanticToken, SymbolKind, TextDocumentContentChangeEvent, Url,
-    WorkspaceFolder,
+    self, CompletionItem, CompletionItemKind, DiagnosticSeverity, DidChangeTextDocumentParams,
+    InlayHint, InlayHintLabel, PositionEncodingKind, SemanticToken, SymbolKind,
+    TextDocumentContentChangeEvent, Url, WorkspaceFolder,
 };
 use tree_sitter_c2rust::{InputEdit, Node, Parser, Query, QueryCursor, StreamingIterator, Tree};
 
@@ -1225,92 +1225,75 @@ impl InternalDocument {
         self.stage2.all_frame_infos.values()
     }
 
-    pub fn try_keywords_at_position(&self, cursor: Position) -> Vec<String> {
-        let mut parser = lock_global_parser();
-        let rope = self.rope().clone();
-        let tree = self.tree().clone();
+    pub fn get_keyword_competions_at(&self, pos: Position) -> Vec<String> {
+        let pos_one_left = pos.moved_left(1, self.rope());
+        let node = self
+            .tree()
+            .root_node()
+            .named_descendant_for_point_range(pos_one_left.into(), pos_one_left.into())
+            .expect("The pos to be in at least one node");
 
-        let line = rope
-            .get_line(cursor.line() as usize)
+        let line = self
+            .rope()
+            .get_line(pos.line() as usize)
             .map(|s| s.to_string())
             .unwrap_or_default();
-        let partial = word_before_character(cursor.character_byte() as usize, &line);
+        let partial = word_before_character(pos.character_byte() as usize, &line);
 
-        debug!("Cursor node text is {partial:?}");
+        let mut lei = LANGUAGE
+            .lookahead_iterator(node.parse_state())
+            .expect("Valid state");
 
-        let keywords = &*queries::KEYWORDS;
-
-        let kws = keywords
-            .iter()
-            .filter(|k| k.starts_with(&partial))
-            .collect_vec();
-
-        debug!("Checking {} keywords", kws.len());
-
-        kws.iter()
-            .map(|kw| {
-                let mut rope_version = rope.clone();
-                let change = kw[partial.len()..].to_string() + " a";
-
-                let mut tree = tree.clone(); // This is fast
-
-                // Must come before the rope is changed!
-                let cursor_byte_index = cursor.byte_index(&rope_version);
-
-                rope_version.insert(cursor.char_index(&rope_version), &change);
-
-                // Must come after rope changed!
-                let new_end_byte = cursor_byte_index + change.len();
-                let new_end_position = Position::new_from_byte_index(&rope_version, new_end_byte);
-
-                let edit = InputEdit {
-                    // Old range is just a zero size range
-                    start_byte: cursor_byte_index,
-                    start_position: cursor.into(),
-                    old_end_byte: cursor_byte_index,
-                    old_end_position: cursor.into(),
-
-                    new_end_byte,
-                    new_end_position: new_end_position.into(),
-                };
-                tree.edit(&edit);
-
-                let rope_provider = RopeProvider::new(&rope_version);
-                let new_tree = parser
-                    .parse_with_options(
-                        &mut |byte_idx, _| rope_provider.chunk_callback(byte_idx),
-                        Some(&tree),
-                        None,
-                    )
-                    .expect("language to be set, no timeout to be used, no cancellation flag");
-
-                let cursor_one_left = cursor.moved_left(1, &rope);
-                let cursor_node_version = new_tree
-                    .root_node()
-                    .named_descendant_for_point_range(
-                        cursor_one_left.into(),
-                        cursor_one_left.into(),
-                    )
-                    .ok_or(Error::PositionOutOfBounds(cursor_one_left))?;
-
-                debug!("{cursor_node_version:#?} is {}", cursor_node_version.kind());
-
-                if cursor_node_version.kind().starts_with("keyword_")
-                    && !cursor_node_version
-                        .parent()
-                        .expect("keyword to have parent")
-                        .is_error()
-                {
-                    debug!("Found possible keyword {kw}!");
-                    Ok(Some((*kw).to_string()))
-                } else {
-                    debug!("{kw} is not possible");
-                    Ok(None)
-                }
-            })
-            .filter_map_ok(|x| x)
-            .filter_and_log()
+        lei.iter_names()
+            .filter_map(|kind| (*queries::KEYWORDS_MAP).get(kind).cloned())
+            .filter(|kw| kw.starts_with(&partial))
             .collect_vec()
+    }
+
+    pub fn get_iri_completions_at(
+        &self,
+        pos: Position,
+        workspace: &Workspace,
+    ) -> Vec<(String, String, String)> {
+        let pos_one_left = pos.moved_left(1, self.rope());
+
+        let node = self
+            .tree()
+            .root_node()
+            .named_descendant_for_point_range(pos_one_left.into(), pos_one_left.into())
+            .expect("The pos to be in at least one node");
+
+        // Generate the list of iris that can be inserted.
+        let partial_text = node_text(&node, self.rope()).to_string();
+
+        if node.kind() == "simple_iri" {
+            debug!("Try iris...");
+
+            workspace
+                .search_frame(&partial_text)
+                .into_iter()
+                .unique_by(|(_, iri, _)| iri.clone())
+                .sorted_unstable_by_key(|(v, _, _)| v.clone())
+                .filter_map(|(full, maybe_full_iri, frame)| {
+                    // TODO this will not be correct for all workspace frames (I think)
+                    let iri = self.full_iri_to_shorter_iri(&maybe_full_iri);
+
+                    if iri == partial_text {
+                        None
+                    } else {
+                        Some((
+                            frame.label().unwrap_or(full),
+                            frame.info_display(workspace),
+                            iri,
+                        ))
+                    }
+                })
+                // TODO #29 add items for simple iri, abbriviated iri and full iri
+                // Take the shortest one maybe
+                .collect_vec()
+        } else {
+            Vec::new()
+        }
     }
 
     pub fn sematic_tokens(

--- a/crates/owl-ms-language-server/src/workspace.rs
+++ b/crates/owl-ms-language-server/src/workspace.rs
@@ -1159,10 +1159,19 @@ impl InternalDocument {
             .next()
     }
 
-    /// Converts a full IRI maybe into an abbreviated IRI or just adds < >
+    /// Converts a full IRI maybe into an abbreviated IRI or just adds < > braces
     pub fn full_iri_to_shorter_iri(&self, full_iri: &str) -> String {
         self.full_iri_to_abbreviated_iri(full_iri)
-            .unwrap_or(format!("<{full_iri}>"))
+            .unwrap_or_else(|| {
+                // Sometimes the IRI can not be converted but it is also not a full IRI or kind of URI.
+                // In these cases it is best to just skip adding the < > braces.
+                // This is probibly caused by not having a default/empty prefix.
+                if full_iri.contains("://") {
+                    format!("<{full_iri}>")
+                } else {
+                    full_iri.to_string()
+                }
+            })
     }
 
     pub fn inlay_hint(
@@ -1250,6 +1259,7 @@ impl InternalDocument {
             .collect_vec()
     }
 
+    // (Label, Details, Insert Text)
     pub fn get_iri_completions_at(
         &self,
         pos: Position,

--- a/crates/owl-ms-language-server/src/workspace.rs
+++ b/crates/owl-ms-language-server/src/workspace.rs
@@ -48,9 +48,9 @@ use std::{
 };
 use tokio::task::JoinHandle;
 use tower_lsp::lsp_types::{
-    self, CompletionItem, CompletionItemKind, DiagnosticSeverity, DidChangeTextDocumentParams,
-    InlayHint, InlayHintLabel, PositionEncodingKind, SemanticToken, SymbolKind,
-    TextDocumentContentChangeEvent, Url, WorkspaceFolder,
+    self, DiagnosticSeverity, DidChangeTextDocumentParams, InlayHint, InlayHintLabel,
+    PositionEncodingKind, SemanticToken, SymbolKind, TextDocumentContentChangeEvent, Url,
+    WorkspaceFolder,
 };
 use tree_sitter_c2rust::{InputEdit, Node, Parser, Query, QueryCursor, StreamingIterator, Tree};
 
@@ -1236,11 +1236,25 @@ impl InternalDocument {
 
     pub fn get_keyword_competions_at(&self, pos: Position) -> Vec<String> {
         let pos_one_left = pos.moved_left(1, self.rope());
-        let node = self
+        let mut node = self
             .tree()
             .root_node()
             .named_descendant_for_point_range(pos_one_left.into(), pos_one_left.into())
             .expect("The pos to be in at least one node");
+
+        let mut lei = if node.parent().is_none() {
+            LANGUAGE
+                .lookahead_iterator(1)
+                .expect("state 1 should be valid")
+        } else {
+            let mut lei = LANGUAGE.lookahead_iterator(node.parse_state());
+            while lei.is_none() {
+                let parent = node.parent().unwrap(); // TODO
+                node = parent;
+                lei = LANGUAGE.lookahead_iterator(node.parse_state());
+            }
+            lei.expect("while none loop should have set it to some")
+        };
 
         let line = self
             .rope()
@@ -1249,11 +1263,8 @@ impl InternalDocument {
             .unwrap_or_default();
         let partial = word_before_character(pos.character_byte() as usize, &line);
 
-        let mut lei = LANGUAGE
-            .lookahead_iterator(node.parse_state())
-            .expect("Valid state");
-
         lei.iter_names()
+            .inspect(|n| debug!("- LEI name: {n}"))
             .filter_map(|kind| (*queries::KEYWORDS_MAP).get(kind).cloned())
             .filter(|kw| kw.starts_with(&partial))
             .collect_vec()

--- a/crates/owl-ms-language-server/src/workspace.rs
+++ b/crates/owl-ms-language-server/src/workspace.rs
@@ -1242,16 +1242,24 @@ impl InternalDocument {
             .named_descendant_for_point_range(pos_one_left.into(), pos_one_left.into())
             .expect("The pos to be in at least one node");
 
+        // The first case is needed, becaus it catches the empty doc case
         let mut lei = if node.parent().is_none() {
+            // Has no parent -> Is root
             LANGUAGE
                 .lookahead_iterator(1)
                 .expect("state 1 should be valid")
         } else {
             let mut lei = LANGUAGE.lookahead_iterator(node.parse_state());
+
             while lei.is_none() {
-                let parent = node.parent().unwrap(); // TODO
-                node = parent;
-                lei = LANGUAGE.lookahead_iterator(node.parse_state());
+                let parent = node.parent();
+                if let Some(parent) = parent {
+                    node = parent;
+                    lei = LANGUAGE.lookahead_iterator(node.parse_state());
+                } else {
+                    // Has no parent -> Is root
+                    lei = LANGUAGE.lookahead_iterator(1);
+                }
             }
             lei.expect("while none loop should have set it to some")
         };

--- a/editors/code/client/package-lock.json
+++ b/editors/code/client/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-owl-ms",
-	"version": "0.8.0",
+	"version": "0.13.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-owl-ms",
-			"version": "0.8.0",
+			"version": "0.13.1",
 			"license": "MIT",
 			"dependencies": {
 				"glob": "^11.0.0",

--- a/editors/code/client/src/test/smoke.test.ts
+++ b/editors/code/client/src/test/smoke.test.ts
@@ -65,8 +65,9 @@ suite('Should do smoke', () => {
   });
 
   test('Completion at class reference position', async () => {
+    await setTestContent(originalContent + '\nClass: SomeOtherClass\nSubClassOf: S');
     const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
-      'vscode.executeCompletionItemProvider', docUri, new vscode.Position(PERSON_REF_LINE, PERSON_REF_COL)
+      'vscode.executeCompletionItemProvider', docUri, doc.positionAt(doc.getText().length)
     );
     assert.ok(completions.items.length > 0);
     const labels = completions.items.map(i =>
@@ -76,11 +77,11 @@ suite('Should do smoke', () => {
   });
 
   test('Edited class appears in completions', async () => {
-    await setTestContent(originalContent + '\n\nClass: SmokeTestClass\n');
+    await setTestContent(originalContent + '\n\nClass: SmokeTestClass\nClass: SomeOtherClass\nSubClassOf: S');
     await sleep(1500);
 
     const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
-      'vscode.executeCompletionItemProvider', docUri, new vscode.Position(PERSON_REF_LINE, PERSON_REF_COL)
+      'vscode.executeCompletionItemProvider', docUri, doc.positionAt(doc.getText().length)
     );
     const labels = completions.items.map(i =>
       typeof i.label === 'string' ? i.label : i.label.label

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-owl-ms",
-	"version": "0.8.0",
+	"version": "0.13.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-owl-ms",
-			"version": "0.8.0",
+			"version": "0.13.1",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"devDependencies": {

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,17 @@
           ${pkgs.cargo-tarpaulin}/bin/cargo-tarpaulin --engine llvm --out html && \
           xdg-open tarpaulin-report.html
         '';
+
+        e2e-test = pkgs.writeShellScriptBin "e2e-test" ''
+          export __OWL_MS_LSP_SERVER_DEBUG = "$(pwd)/target/debug/owl-ms-language-server";
+          cargo build
+
+          pushd editors/code
+          npm run compile
+
+          # This is needed for loading the correct libs for vscode
+          ${pkgs.steam-run-free}/bin/steam-run npm test
+        '';
       in
       with pkgs;
       {
@@ -82,10 +93,6 @@
           );
           __OWL_MS_LSP_SERVER_DEBUG = "/home/janek/Git/owl-ms-language-server/target/debug/owl-ms-language-server";
           nativeBuildInputs = with pkgs; [
-            # cargo
-            # clippy
-            # rust-analyzer
-            # rustc
             nodejs_22
             tree-sitter
 
@@ -94,6 +101,10 @@
             samply
             owl-ms-language-server
             tarpaulin-report
+            e2e-test
+
+            # for e2e and client
+            typescript-language-server
           ];
         };
       }


### PR DESCRIPTION
closes #150 

## Description

Replaces the reparsing of all matching keywords with a look ahead iterator. The speedup is huge.

## Checklist

- [x] New behavior is covered by tests, or existing tests were updated
  - The same tests apply that where written before
- [x] No unwrap()/todo!()/println!/dbg! in non-test code (expect() is ok
- [x] Position encoding handled on all enpoints
- [x] No clone() of huge structs added
