### PR TITLE
fix: stale diagnostics

### DIFF
--- a/crates/owl-ms-language-server/src/tests.rs
+++ b/crates/owl-ms-language-server/src/tests.rs
@@ -4322,6 +4322,90 @@ async fn backend_did_change_with_large_syntax_change_should_update_prefixes() {
     );
 }
 
+/// bug #168 wront diagnostics
+#[test(tokio::test)]
+async fn backend_did_change_with_some_should_prune_diagnostics() {
+    setup();
+    // Arrange
+    let service = arrange_backend(None, vec![]).await;
+    let dir = TempDir::new("owl-ms-test").unwrap();
+    let ontology_url = Url::from_file_path(dir.path().join("file.omn")).unwrap();
+
+    let ontology = indoc! { r#"
+        Ontology: Dev
+        
+            Class: Janek
+                SubClassOf: Person, Developer
+
+            Class: Person
+
+            Class: Developer
+                SubClassOf: Person some X
+    "#};
+
+    service
+        .inner()
+        .did_open(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: ontology_url.clone(),
+                language_id: "owl2md".to_string(),
+                version: 0,
+                text: ontology.to_string(),
+            },
+        })
+        .await;
+
+    // Act
+
+    service
+        .inner()
+        .did_change(DidChangeTextDocumentParams {
+            text_document: VersionedTextDocumentIdentifier {
+                uri: ontology_url.clone(),
+                version: 1,
+            },
+            content_changes: vec![TextDocumentContentChangeEvent {
+                text: "".into(),
+                range: Some(lsp_types::Range {
+                    // Deletes the X
+                    start: lsp_types::Position::new(8, 32),
+                    end: lsp_types::Position::new(8, 33),
+                }),
+                range_length: None,
+            }],
+        })
+        .await;
+
+    // Assert
+
+    let sync = service.inner().read_sync().await;
+    let workspaces = sync.workspaces();
+    let workspace = workspaces.iter().exactly_one().unwrap();
+    let document = workspace
+        .internal_documents()
+        .exactly_one()
+        .unwrap_or_else(|_| panic!("Multiple documents"));
+
+    assert_eq!(
+        document.rope().to_string(),
+        indoc! { r#"
+        Ontology: Dev
+        
+            Class: Janek
+                SubClassOf: Person, Developer
+
+            Class: Person
+
+            Class: Developer
+                SubClassOf: Person some 
+        "#}
+    );
+
+    let diagnostics = document.diagnostics(workspace);
+
+    assert!(!diagnostics.iter().any(|d| d.label().contains('X')));
+}
+
 /////////////////////////
 // Fuzz / property-based tests
 /////////////////////////

--- a/crates/owl-ms-language-server/src/workspace.rs
+++ b/crates/owl-ms-language-server/src/workspace.rs
@@ -797,7 +797,7 @@ fn retain_vec_rb_on_remove<T, F: FnMut(&RangeBox<T>)>(
 ) {
     items.retain(|range_box| {
         for sc in post_change_ranges {
-            if range_box.range().overlaps(sc) {
+            if range_box.range().overlaps(sc) || range_box.range().is_zero() {
                 on_remove(range_box);
                 return false;
             }
@@ -2228,7 +2228,7 @@ impl QueriedDocument {
         // post_change_ranges, so I can just use the ranges.
         self.imports.retain(|import| {
             for sc in post_change_ranges {
-                if import.range().overlaps(sc) {
+                if import.range().overlaps(sc) || import.range().is_zero() {
                     return false;
                 }
             }
@@ -2938,6 +2938,11 @@ fn semantic_errors(doc: &InternalDocument, workspace: &Workspace) -> Vec<Diagnos
         .iter()
         .map(|rb| rb.value().iri.clone())
         .collect();
+
+    debug!(
+        "semantic_errors / doc {:?} uses {uses:#?} defines {defines:#?}",
+        doc.id
+    );
 
     let imports_recursive = timeit("semantic errors  reachable", || {
         // This takes the longes :<


### PR DESCRIPTION
closes #168 

## Description

Sometimes, when an info and its text is deleted, the range that this covers is zero sized. So the start and end are the same. When this happens, the range can no longer overlap with another ranges border.

```
    | 0 | 1 | 2 | 3 |
          ^   
	      |     
Range 1--/

          ^-------^
              |
  Range 2----/
```

Range 1 is 1 .. 1
Range 2 is 1 .. 3

These do not overlap because the range 1 is zero sized.

When this happens the info gets stale.
This PR fixes the staleness by flagging zero sized infos as dirty.


## Checklist

- [x] New behavior is covered by tests, or existing tests were updated
- [x] No unwrap()/todo!()/println!/dbg! in non-test code (expect() is ok
- [x] Position encoding handled on all enpoints
- [x] No clone() of huge structs added
