### PR TITLE
feat: add lai & intersect with old method + parent chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,7 +1353,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owl-ms-language-server"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cached",
  "cc",
@@ -2688,7 +2688,7 @@ checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
 
 [[package]]
 name = "tree-sitter-owl-ms"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cc",
  "tree-sitter-c2rust",

--- a/crates/owl-ms-language-server/proptest-regressions/tests.txt
+++ b/crates/owl-ms-language-server/proptest-regressions/tests.txt
@@ -23,3 +23,4 @@ cc c77b31f9f95a5c3cc7ca181eed84915c4b876a253cb147dcc747282d142edcc6 # shrinks to
 cc e64dfa4176b1c4556804c4b9f2423fe3cc87e41bbf7593348e39b8586df0a888 # shrinks to line = 1, col = 32, insert_text = "VA58d8u\t Y swyz3fs5m 6VxR\n\tJS3   95\n\n8"
 cc 5902a05ea5dd6118061f78f8a024100cfe106b60f8cd0014e12da4e958eb7127 # shrinks to line = 6, col = 12, insert_text = " "
 cc 8db8decfafe4ddb7ab9f0a12ece93f44f9c00a16135d048a4796a5bd11dbbe51 # shrinks to line = 0, col = 0, insert_text = "\nPrefix: x: <http://invalis/x/>\"\n"
+cc e53fe16ed21dcf1249342cbbe287a6197230ddb96ba09c87684dffabcb5c336b # shrinks to line = 2, col = 40, insert_text = "\nPrefix: x: <http://invalis/x/>\"\n"

--- a/crates/owl-ms-language-server/src/consts.rs
+++ b/crates/owl-ms-language-server/src/consts.rs
@@ -280,7 +280,7 @@ pub fn keyword_hover_info(kind: &str) -> String {
                 - [Universal Quantification over Data Properties](https://www.w3.org/TR/owl2-syntax/#Universal_Quantification_2)
             "}.to_string(),
             "keyword_self" => indoc! {"
-                `self`
+                `Self`
 
                 *Class expression* 
 
@@ -291,7 +291,7 @@ pub fn keyword_hover_info(kind: &str) -> String {
                 Example:
                 ```owl-ms
                 Class: Person
-                    SubClassOf: likes self
+                    SubClassOf: likes Self
                 ```
 
                 [Specification](https://www.w3.org/TR/owl2-syntax/#Self-Restriction)

--- a/crates/owl-ms-language-server/src/queries.rs
+++ b/crates/owl-ms-language-server/src/queries.rs
@@ -60,6 +60,8 @@ pub struct AllQueries {
     pub frame_query: Query,
     pub prefix: Query,
     pub ontology: Query,
+    pub error: Query,
+    pub missing: Query,
 }
 
 // All queries are in one struct for easy testing. Invalid ones are detected by unit tests.
@@ -121,6 +123,20 @@ pub static ALL_QUERIES: LazyLock<AllQueries> = LazyLock::new(|| AllQueries {
         &LANGUAGE,
         "
             (ontology iri: (_)@iri version_iri: (_)@version_iri ? )
+        ",
+    )
+    .expect("valid query"),
+    error: Query::new(
+        &LANGUAGE,
+        "
+            (ERROR)@error
+        ",
+    )
+    .expect("valid query"),
+    missing: Query::new(
+        &LANGUAGE,
+        "
+            (MISSING)@missing
         ",
     )
     .expect("valid query"),

--- a/crates/owl-ms-language-server/src/tests.rs
+++ b/crates/owl-ms-language-server/src/tests.rs
@@ -1275,7 +1275,7 @@ async fn backend_import_resolve_should_load_documents() {
             ),
             WorkspaceMember::OmnFile {
                 name: "foobaronto.omn".into(),
-                content: "".into(),
+                content: "Ontology: X".into(),
             },
         ]
     });
@@ -4509,8 +4509,14 @@ async fn backend_diagnostics_with_syntax_error_should_report_nice_message() {
 
     // Assert
     let diagnostics = document.diagnostics(workspace);
-    dbg!(diagnostics);
-    panic!();
+    info!("{:#?}", diagnostics);
+    assert!(diagnostics
+        .iter()
+        .filter(|d| d.label().contains("Some")
+            && d.label().contains("Value")
+            && d.label().contains("Self"))
+        .exactly_one()
+        .is_ok());
 }
 
 /////////////////////////

--- a/crates/owl-ms-language-server/src/tests.rs
+++ b/crates/owl-ms-language-server/src/tests.rs
@@ -4469,6 +4469,50 @@ async fn backend_did_change_with_some_should_prune_diagnostics() {
     assert!(!diagnostics.iter().any(|d| d.label().contains('X')));
 }
 
+#[test(tokio::test)]
+async fn backend_diagnostics_with_syntax_error_should_report_nice_message() {
+    setup();
+    // Arrange
+    let service = arrange_backend(None, vec![]).await;
+    let dir = TempDir::new("owl-ms-test").unwrap();
+    let ontology_url = Url::from_file_path(dir.path().join("file.omn")).unwrap();
+
+    let ontology = indoc! { r#"
+        Ontology: Dev
+        
+            Class: Janek
+                SubClassOf: Person Developer
+        #           Syntax Error  ^
+            Class: Developer
+    "#};
+
+    service
+        .inner()
+        .did_open(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: ontology_url.clone(),
+                language_id: "owl2md".to_string(),
+                version: 0,
+                text: ontology.to_string(),
+            },
+        })
+        .await;
+
+    // Act
+    let sync = service.inner().read_sync().await;
+    let workspaces = sync.workspaces();
+    let workspace = workspaces.iter().exactly_one().unwrap();
+    let document = workspace
+        .internal_documents()
+        .exactly_one()
+        .unwrap_or_else(|_| panic!("Multiple documents"));
+
+    // Assert
+    let diagnostics = document.diagnostics(workspace);
+    dbg!(diagnostics);
+    panic!();
+}
+
 /////////////////////////
 // Fuzz / property-based tests
 /////////////////////////

--- a/crates/owl-ms-language-server/src/workspace.rs
+++ b/crates/owl-ms-language-server/src/workspace.rs
@@ -1664,8 +1664,10 @@ impl ParsedDocument {
 
                 let valid_children = parent_chain_children.intersection(&possible_nodes);
 
-                let valid_children: String =
-                    valid_children.map(|nt| node_type_to_string(nt)).join(", ");
+                let valid_children: String = valid_children
+                    .map(|nt| node_type_to_string(nt))
+                    .sorted_unstable()
+                    .join(", ");
 
                 let parent = parent_chain
                     .iter()

--- a/crates/owl-ms-language-server/src/workspace.rs
+++ b/crates/owl-ms-language-server/src/workspace.rs
@@ -837,8 +837,11 @@ impl Diagnostic {
             DiagnosticKind::SyntaxError {
                 valid_children,
                 parent,
+                msg,
             } => {
-                format!("Syntax Error. expected {valid_children} inside {parent}")
+                format!(
+                    "Syntax Error {msg}. Expected\n  {valid_children}\ninside or after\n  {parent}"
+                )
             }
         }
     }
@@ -868,6 +871,7 @@ pub enum DiagnosticKind {
     SyntaxError {
         valid_children: String, // add some nicer info here if needed
         parent: String,
+        msg: String, // Eg. "UNEXPECTED '\n'"
     },
 }
 
@@ -1616,33 +1620,71 @@ impl ParsedDocument {
             let node = cursor.node();
 
             if node.is_error() {
-                // log
+                let leaf = first_leaf(node);
                 let range: Range = cursor.node().range().into();
 
-                // root has no parents so use itself
-                let parent_kind = node.parent().unwrap_or(node).kind();
+                let prev_node = node.prev_sibling().unwrap_or(node.parent().unwrap_or(node));
 
-                if let Some(static_node) = NODE_TYPES.get(parent_kind) {
-                    let valid_children: String = Itertools::intersperse(
-                        static_node
-                            .children
-                            .types
-                            .iter()
-                            .map(|sn| node_type_to_string(&sn.type_)),
-                        ", ".to_string(),
-                    )
-                    .collect();
+                let mut prev = if let Some(prev_sib) = node.prev_sibling() {
+                    let prev_sibs_last_leaf = get_last_leaf(prev_sib);
+                    prev_sibs_last_leaf
+                } else {
+                    prev_node
+                };
 
-                    let parent = node_type_to_string(parent_kind);
-
-                    diagnostics.push(Diagnostic {
-                        range,
-                        kind: DiagnosticKind::SyntaxError {
-                            valid_children,
-                            parent,
-                        },
-                    });
+                let mut parent_chain = vec![prev.kind()];
+                while let Some(par) = prev.parent() {
+                    parent_chain.push(par.kind());
+                    prev = par;
                 }
+
+                let possible_nodes = possible_nodes(node)
+                    .iter()
+                    .map(std::string::ToString::to_string)
+                    .collect();
+                debug!("Possible nodes: {possible_nodes:#?}");
+                debug!("Parent chain: {parent_chain:#?}");
+
+                let parent_chain_children = parent_chain
+                    .iter()
+                    .flat_map(|kind| {
+                        NODE_TYPES
+                            .get(&(*kind).to_string())
+                            .iter()
+                            .flat_map(|t| {
+                                t.children
+                                    .types
+                                    .iter()
+                                    .map(|c| c.type_.clone())
+                                    .collect_vec()
+                            })
+                            .collect_vec()
+                    })
+                    .collect::<HashSet<_>>();
+
+                let valid_children = parent_chain_children.intersection(&possible_nodes);
+
+                let valid_children: String =
+                    valid_children.map(|nt| node_type_to_string(nt)).join(", ");
+
+                let parent = parent_chain
+                    .iter()
+                    .map(|parent_kind| node_type_to_string(parent_kind))
+                    .join(" < ");
+
+                diagnostics.push(Diagnostic {
+                    range,
+                    kind: DiagnosticKind::SyntaxError {
+                        valid_children,
+                        parent,
+                        msg: leaf
+                            .to_string()
+                            .trim_start_matches('(')
+                            .trim_end_matches(')')
+                            .to_string(),
+                    },
+                });
+
                 // move along
                 while !cursor.goto_next_sibling() {
                     // move out
@@ -1677,6 +1719,59 @@ impl ParsedDocument {
         }
     }
 }
+
+fn first_leaf(node: Node<'_>) -> Node<'_> {
+    let mut current = node;
+    while let Some(child) = current.child(0) {
+        current = child;
+    }
+    current
+}
+
+fn possible_nodes(node: Node<'_>) -> HashSet<&'static str> {
+    if !node.is_error() {
+        return HashSet::new();
+    }
+
+    let state = first_leaf(node).parse_state();
+
+    let names = LANGUAGE
+        .lookahead_iterator(state)
+        .map(|mut it| it.iter_names().collect())
+        .unwrap_or_default();
+
+    names
+}
+
+fn get_last_leaf(node: Node<'_>) -> Node<'_> {
+    debug!("Get last leaf of {node}");
+    if node.child_count() > 0 {
+        if let Some(c) = node.child(node.child_count() - 1) {
+            debug!("Goto child {c} with index {}", node.child_count() - 1);
+            get_last_leaf(c)
+        } else {
+            node
+        }
+    } else {
+        debug!("End on {node}");
+        node
+    }
+}
+
+// for debugging
+// fn print_node(node: Node<'_>, depth: usize) {
+//     debug!(
+//         "{}- {} ({}) {} {} {node:?}",
+//         " ".repeat(depth),
+//         node.kind(),
+//         node.grammar_name(),
+//         node.parse_state(),
+//         node.next_parse_state()
+//     );
+//     for i in 0..node.child_count() {
+//         print_node(node.child(i).unwrap(), depth + 1);
+//     }
+// }
 
 /// .
 ///
@@ -3023,11 +3118,11 @@ fn semantic_errors(doc: &InternalDocument, workspace: &Workspace) -> Vec<Diagnos
 }
 
 fn node_type_to_string(node_type: &str) -> String {
-    Itertools::intersperse(
-        node_type.split_terminator('_').map(capitalize_string),
-        " ".to_string(),
-    )
-    .collect()
+    node_type
+        .trim_start_matches("keyword_")
+        .split_terminator('_')
+        .map(capitalize_string)
+        .join(" ")
 }
 
 fn capitalize_string(s: &str) -> String {


### PR DESCRIPTION
closes #170 

## Description

Uses a look ahead iterator combined with meta information to predict the next possible nodes. It is not perfect but better that the status quo. 

## Checklist

- [x] New behavior is covered by tests, or existing tests were updated
- [x] No unwrap()/todo!()/println!/dbg! in non-test code (expect() is ok
- [x] Position encoding handled on all enpoints
- [x] No clone() of huge structs added
